### PR TITLE
Change strictly above to above and equal on PlaylistMin*Tracks

### DIFF
--- a/DynamicPlaylists3/Playlists/albums/albums_01_random.sql.xml
+++ b/DynamicPlaylists3/Playlists/albums/albums_01_random.sql.xml
@@ -27,7 +27,7 @@ create temporary table dynamicplaylist_random_albums as
 								genre_track.genre = genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks'
+			having totaltrackcount >= 'PlaylistMinAlbumTracks'
 		order by random()
 		limit 1;
 select distinct tracks.url from tracks

--- a/DynamicPlaylists3/Playlists/albums/albums_02_topavgrated.sql.xml
+++ b/DynamicPlaylists3/Playlists/albums/albums_02_topavgrated.sql.xml
@@ -30,7 +30,7 @@ create temporary table dynamicplaylist_random_albums as
 								genre_track.genre = genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks'
+			having totaltrackcount >= 'PlaylistMinAlbumTracks'
 		order by avgrating desc, random()
 		limit 30) as topavgrated
 	order by random()

--- a/DynamicPlaylists3/Playlists/albums/albums_03_withmostratedsongs.sql.xml
+++ b/DynamicPlaylists3/Playlists/albums/albums_03_withmostratedsongs.sql.xml
@@ -30,7 +30,7 @@ create temporary table dynamicplaylist_random_albums as
 								genre_track.genre = genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks'
+			having totaltrackcount >= 'PlaylistMinAlbumTracks'
 		order by totaltrackcount desc, random()
 		limit 30) as mostratedtracks
 	order by random()

--- a/DynamicPlaylists3/Playlists/albums/albums_04_withratedsongs.sql.xml
+++ b/DynamicPlaylists3/Playlists/albums/albums_04_withratedsongs.sql.xml
@@ -23,7 +23,7 @@ create temporary table dynamicplaylist_random_albums as
 					else 1
 				end
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks'
+			having totaltrackcount >= 'PlaylistMinAlbumTracks'
 		order by random()
 		limit 1;
 select distinct tracks.url from tracks

--- a/DynamicPlaylists3/Playlists/albums/albums_05_withtopratedsongs.sql.xml
+++ b/DynamicPlaylists3/Playlists/albums/albums_05_withtopratedsongs.sql.xml
@@ -29,7 +29,7 @@ create temporary table dynamicplaylist_random_albums as
 								genre_track.genre = genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks'
+			having totaltrackcount >= 'PlaylistMinAlbumTracks'
 		order by random()
 		limit 1;
 select distinct tracks.url from tracks

--- a/DynamicPlaylists3/Playlists/albums/albums_06_notrated.sql.xml
+++ b/DynamicPlaylists3/Playlists/albums/albums_06_notrated.sql.xml
@@ -30,7 +30,7 @@ create temporary table dynamicplaylist_random_albums as
 									genre_track.genre = genres.id and
 									genres.name in ('PlaylistExcludedGenres'))
 			group by tracks.album
-				having totaltrackcount > 'PlaylistMinAlbumTracks' and sumrating = 0
+				having totaltrackcount >= 'PlaylistMinAlbumTracks' and sumrating = 0
 			order by sumrating asc, random()
 			limit 30) as notrated
 	where sumrating = 0

--- a/DynamicPlaylists3/Playlists/albums/albums_07_mostplayed_absolute.sql.xml
+++ b/DynamicPlaylists3/Playlists/albums/albums_07_mostplayed_absolute.sql.xml
@@ -30,7 +30,7 @@ create temporary table dynamicplaylist_random_albums as
 								genre_track.genre = genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks'
+			having totaltrackcount >= 'PlaylistMinAlbumTracks'
 		order by sumcount desc, random()
 		limit 30) as mostplayed
 	order by random()

--- a/DynamicPlaylists3/Playlists/albums/albums_08_mostplayed_avg.sql.xml
+++ b/DynamicPlaylists3/Playlists/albums/albums_08_mostplayed_avg.sql.xml
@@ -30,7 +30,7 @@ create temporary table dynamicplaylist_random_albums as
 								genre_track.genre = genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks'
+			having totaltrackcount >= 'PlaylistMinAlbumTracks'
 		order by avgcount desc, random()
 		limit 30) as mostavgplayed
 	order by random()

--- a/DynamicPlaylists3/Playlists/albums/albums_09_leastplayed_absolute.sql.xml
+++ b/DynamicPlaylists3/Playlists/albums/albums_09_leastplayed_absolute.sql.xml
@@ -30,7 +30,7 @@ create temporary table dynamicplaylist_random_albums as
 								genre_track.genre = genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks'
+			having totaltrackcount >= 'PlaylistMinAlbumTracks'
 		order by sumcount asc, random()
 		limit 30) as leastplayed
 	order by random()

--- a/DynamicPlaylists3/Playlists/albums/albums_10_leastplayed_avg.sql.xml
+++ b/DynamicPlaylists3/Playlists/albums/albums_10_leastplayed_avg.sql.xml
@@ -30,7 +30,7 @@ create temporary table dynamicplaylist_random_albums as
 								genre_track.genre = genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks'
+			having totaltrackcount >= 'PlaylistMinAlbumTracks'
 		order by avgcount asc, random()
 		limit 30) as leastavgplayed
 	order by random()

--- a/DynamicPlaylists3/Playlists/albums/albums_11_virtuallibrary_random.sql.xml
+++ b/DynamicPlaylists3/Playlists/albums/albums_11_virtuallibrary_random.sql.xml
@@ -28,7 +28,7 @@ create temporary table dynamicplaylist_random_albums as
 								genre_track.genre = genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks'
+			having totaltrackcount >= 'PlaylistMinAlbumTracks'
 		order by random()
 		limit 1;
 select distinct tracks.url from tracks

--- a/DynamicPlaylists3/Playlists/albums/albums_12_recentlyaddedplayed.sql.xml
+++ b/DynamicPlaylists3/Playlists/albums/albums_12_recentlyaddedplayed.sql.xml
@@ -35,7 +35,7 @@ create temporary table dynamicplaylist_random_albums as
 								genre_track.genre = genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks'
+			having totaltrackcount >= 'PlaylistMinAlbumTracks'
 				and
 					case
 						when 'PlaylistParameter1'=2 then ((strftime('%s',DATE('NOW','-'PlaylistPeriodRecentlyPlayed' DAY'))-max(ifnull(tracks_persistent.lastPlayed,0))) > 0)

--- a/DynamicPlaylists3/Playlists/albums/albums_13_neverplayed.sql.xml
+++ b/DynamicPlaylists3/Playlists/albums/albums_13_neverplayed.sql.xml
@@ -28,7 +28,7 @@ create temporary table dynamicplaylist_random_albums as
 								genre_track.genre = genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks' and sumplaycount = 0
+			having totaltrackcount >= 'PlaylistMinAlbumTracks' and sumplaycount = 0
 		order by random()
 		limit 1;
 select distinct tracks.url from tracks

--- a/DynamicPlaylists3/Playlists/albums/albums_14_playedlongago.sql.xml
+++ b/DynamicPlaylists3/Playlists/albums/albums_14_playedlongago.sql.xml
@@ -29,7 +29,7 @@ create temporary table dynamicplaylist_random_albums as
 								genre_track.genre = genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks' and (strftime('%s',DATE('NOW','-'PlaylistPeriodPlayedLongAgo' YEAR')) - max(ifnull(tracks_persistent.lastPlayed,0))) > 0
+			having totaltrackcount >= 'PlaylistMinAlbumTracks' and (strftime('%s',DATE('NOW','-'PlaylistPeriodPlayedLongAgo' YEAR')) - max(ifnull(tracks_persistent.lastPlayed,0))) > 0
 		order by random()
 		limit 1;
 select distinct tracks.url from tracks

--- a/DynamicPlaylists3/Playlists/artists/artists_01_random.sql.xml
+++ b/DynamicPlaylists3/Playlists/artists/artists_01_random.sql.xml
@@ -28,7 +28,7 @@ create temporary table dynamicplaylist_random_contributors as
 					else 1
 				end
 		group by contributor_track.contributor
-			having totaltrackcount > 'PlaylistMinArtistTracks'
+			having totaltrackcount >= 'PlaylistMinArtistTracks'
 		order by random()
 		limit 1;
 select distinct tracks.url from tracks

--- a/DynamicPlaylists3/Playlists/artists/artists_02_topavgrated.sql.xml
+++ b/DynamicPlaylists3/Playlists/artists/artists_02_topavgrated.sql.xml
@@ -31,7 +31,7 @@ create temporary table dynamicplaylist_random_contributors as
 					else 1
 				end
 		group by contributor_track.contributor
-			having totaltrackcount > 'PlaylistMinArtistTracks'
+			having totaltrackcount >= 'PlaylistMinArtistTracks'
 		order by avgrating desc, random()
 			limit 30) as topavgrated
 	order by random()

--- a/DynamicPlaylists3/Playlists/artists/artists_03_withmostratedsongs.sql.xml
+++ b/DynamicPlaylists3/Playlists/artists/artists_03_withmostratedsongs.sql.xml
@@ -32,7 +32,7 @@ create temporary table dynamicplaylist_random_contributors as
 					else 1
 				end
 		group by contributor_track.contributor
-			having totaltrackcount > 'PlaylistMinArtistTracks'
+			having totaltrackcount >= 'PlaylistMinArtistTracks'
 		order by totaltrackcount desc, random()
 			limit 30) as mostrated
 	order by random()

--- a/DynamicPlaylists3/Playlists/artists/artists_04_withratedsongs.sql.xml
+++ b/DynamicPlaylists3/Playlists/artists/artists_04_withratedsongs.sql.xml
@@ -30,7 +30,7 @@ create temporary table dynamicplaylist_random_contributors as
 					else 1
 				end
 		group by contributor_track.contributor
-			having totaltrackcount > 'PlaylistMinArtistTracks'
+			having totaltrackcount >= 'PlaylistMinArtistTracks'
 		order by random()
 		limit 1;
 select distinct tracks.url from tracks

--- a/DynamicPlaylists3/Playlists/artists/artists_05_withtopratedsongs.sql.xml
+++ b/DynamicPlaylists3/Playlists/artists/artists_05_withtopratedsongs.sql.xml
@@ -30,7 +30,7 @@ create temporary table dynamicplaylist_random_contributors as
 					else 1
 				end
 		group by contributor_track.contributor
-			having totaltrackcount > 'PlaylistMinArtistTracks'
+			having totaltrackcount >= 'PlaylistMinArtistTracks'
 		order by random()
 		limit 1;
 select distinct tracks.url from tracks

--- a/DynamicPlaylists3/Playlists/artists/artists_06_notrated.sql.xml
+++ b/DynamicPlaylists3/Playlists/artists/artists_06_notrated.sql.xml
@@ -31,7 +31,7 @@ create temporary table dynamicplaylist_random_contributors as
 									genre_track.genre = genres.id and
 									genres.name in ('PlaylistExcludedGenres'))
 			group by contributor_track.contributor
-				having totaltrackcount > 'PlaylistMinArtistTracks' and sumrating = 0
+				having totaltrackcount >= 'PlaylistMinArtistTracks' and sumrating = 0
 			order by sumrating asc, random()
 			limit 30) as notrated
 	where sumrating = 0

--- a/DynamicPlaylists3/Playlists/artists/artists_07_mostplayed_absolute.sql.xml
+++ b/DynamicPlaylists3/Playlists/artists/artists_07_mostplayed_absolute.sql.xml
@@ -31,7 +31,7 @@ create temporary table dynamicplaylist_random_contributors as
 					else 1
 				end
 		group by contributor_track.contributor
-			having totaltrackcount > 'PlaylistMinArtistTracks'
+			having totaltrackcount >= 'PlaylistMinArtistTracks'
 		order by sumcount desc, random()
 		limit 30) as mostplayed
 	order by random()

--- a/DynamicPlaylists3/Playlists/artists/artists_08_mostplayed_avg.sql.xml
+++ b/DynamicPlaylists3/Playlists/artists/artists_08_mostplayed_avg.sql.xml
@@ -31,7 +31,7 @@ create temporary table dynamicplaylist_random_contributors as
 					else 1
 				end
 		group by contributor_track.contributor
-			having totaltrackcount > 'PlaylistMinArtistTracks'
+			having totaltrackcount >= 'PlaylistMinArtistTracks'
 		order by avgcount desc, random()
 		limit 30) as mostavgplayed
 	order by random()

--- a/DynamicPlaylists3/Playlists/artists/artists_09_leastplayed_absolute.sql.xml
+++ b/DynamicPlaylists3/Playlists/artists/artists_09_leastplayed_absolute.sql.xml
@@ -31,7 +31,7 @@ create temporary table dynamicplaylist_random_contributors as
 					else 1
 				end
 		group by contributor_track.contributor
-			having totaltrackcount > 'PlaylistMinArtistTracks'
+			having totaltrackcount >= 'PlaylistMinArtistTracks'
 		order by sumcount asc, random()
 		limit 30) as leastplayed
 	order by random()

--- a/DynamicPlaylists3/Playlists/artists/artists_10_leastplayed_avg.sql.xml
+++ b/DynamicPlaylists3/Playlists/artists/artists_10_leastplayed_avg.sql.xml
@@ -31,7 +31,7 @@ create temporary table dynamicplaylist_random_contributors as
 					else 1
 				end
 		group by contributor_track.contributor
-			having totaltrackcount > 'PlaylistMinArtistTracks'
+			having totaltrackcount >= 'PlaylistMinArtistTracks'
 		order by avgcount asc, random()
 		limit 30) as leastavgplayed
 	order by random()

--- a/DynamicPlaylists3/Playlists/artists/artists_11_virtuallibrary_random.sql.xml
+++ b/DynamicPlaylists3/Playlists/artists/artists_11_virtuallibrary_random.sql.xml
@@ -31,7 +31,7 @@ create temporary table dynamicplaylist_random_contributors as
 								genre_track.genre=genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by contributor_track.contributor
-			having totaltrackcount > 'PlaylistMinArtistTracks'
+			having totaltrackcount >= 'PlaylistMinArtistTracks'
 		order by random()
 		limit 1;
 select distinct tracks.url from tracks

--- a/DynamicPlaylists3/Playlists/artists/artists_12_recentlyaddedplayed.sql.xml
+++ b/DynamicPlaylists3/Playlists/artists/artists_12_recentlyaddedplayed.sql.xml
@@ -42,7 +42,7 @@ create temporary table dynamicplaylist_random_contributors as
 				end
 		group by contributor_track.contributor
 			having
-				totaltrackcount > 'PlaylistMinArtistTracks'
+				totaltrackcount >= 'PlaylistMinArtistTracks'
 			and
 				case
 					when 'PlaylistParameter1'=2 then ((strftime('%s',DATE('NOW','-'PlaylistPeriodRecentlyPlayed' DAY'))-max(ifnull(tracks_persistent.lastPlayed,0))) > 0)

--- a/DynamicPlaylists3/Playlists/artists/artists_13_neverplayed.sql.xml
+++ b/DynamicPlaylists3/Playlists/artists/artists_13_neverplayed.sql.xml
@@ -29,7 +29,7 @@ create temporary table dynamicplaylist_random_contributors as
 					else 1
 				end
 		group by contributor_track.contributor
-			having totaltrackcount > 'PlaylistMinArtistTracks' and sumplaycount = 0
+			having totaltrackcount >= 'PlaylistMinArtistTracks' and sumplaycount = 0
 		order by random()
 		limit 1;
 select distinct tracks.url from tracks

--- a/DynamicPlaylists3/Playlists/artists/artists_14_playedlongago.sql.xml
+++ b/DynamicPlaylists3/Playlists/artists/artists_14_playedlongago.sql.xml
@@ -31,7 +31,7 @@ create temporary table dynamicplaylist_random_contributors as
 				end
 		group by contributor_track.contributor
 			having
-				totaltrackcount > 'PlaylistMinArtistTracks'
+				totaltrackcount >= 'PlaylistMinArtistTracks'
 				and ((strftime('%s',DATE('NOW','-'PlaylistPeriodPlayedLongAgo' YEAR'))-max(ifnull(tracks_persistent.lastPlayed,0))) > 0)
 		order by random()
 		limit 1;

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_artists/zz_CONTEXTMENU_for_selected_artist_b01_albums_random.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_artists/zz_CONTEXTMENU_for_selected_artist_b01_albums_random.sql.xml
@@ -33,7 +33,7 @@ create temporary table dynamicplaylist_random_albums as
 							genre_track.genre=genres.id and
 							genres.name in ('PlaylistExcludedGenres'))
 	group by tracks.album
-		having totaltrackcount > 'PlaylistMinArtistTracks'
+		having totaltrackcount >= 'PlaylistMinArtistTracks'
 	order by random()
 	limit 1;
 select distinct tracks.url from tracks

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_artists/zz_CONTEXTMENU_for_selected_artist_b02_albums_topavgrated.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_artists/zz_CONTEXTMENU_for_selected_artist_b02_albums_topavgrated.sql.xml
@@ -33,7 +33,7 @@ create temporary table dynamicplaylist_random_albums as
 							genre_track.genre=genres.id and
 							genres.name in ('PlaylistExcludedGenres'))
 	group by tracks.album
-		having totaltrackcount > 'PlaylistMinArtistTracks'
+		having totaltrackcount >= 'PlaylistMinArtistTracks'
 	order by avgrating desc, random()
 	limit 1;
 select distinct tracks.url from tracks

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_artists/zz_CONTEXTMENU_for_selected_artist_b03_albums_mostplayed_absolute.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_artists/zz_CONTEXTMENU_for_selected_artist_b03_albums_mostplayed_absolute.sql.xml
@@ -33,7 +33,7 @@ create temporary table dynamicplaylist_random_albums as
 							genre_track.genre=genres.id and
 							genres.name in ('PlaylistExcludedGenres'))
 	group by tracks.album
-		having totaltrackcount > 'PlaylistMinArtistTracks'
+		having totaltrackcount >= 'PlaylistMinArtistTracks'
 	order by sumcount desc, random()
 	limit 1;
 select distinct tracks.url from tracks

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_artists/zz_CONTEXTMENU_for_selected_artist_b04_albums_mostplayed_avg.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_artists/zz_CONTEXTMENU_for_selected_artist_b04_albums_mostplayed_avg.sql.xml
@@ -34,7 +34,7 @@ create temporary table dynamicplaylist_random_albums as
 								genre_track.genre=genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinArtistTracks'
+			having totaltrackcount >= 'PlaylistMinArtistTracks'
 		order by avgcount desc, random()
 		limit 30) as mostavgplayed
 	order by random()

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_artists/zz_CONTEXTMENU_for_selected_artist_b05_albums_leastplayed_absolute.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_artists/zz_CONTEXTMENU_for_selected_artist_b05_albums_leastplayed_absolute.sql.xml
@@ -34,7 +34,7 @@ create temporary table dynamicplaylist_random_albums as
 								genre_track.genre=genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinArtistTracks'
+			having totaltrackcount >= 'PlaylistMinArtistTracks'
 		order by sumcount asc, random()
 		limit 30) as leastplayed
 	order by random()

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_artists/zz_CONTEXTMENU_for_selected_artist_b06_albums_leastplayed_avg.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_artists/zz_CONTEXTMENU_for_selected_artist_b06_albums_leastplayed_avg.sql.xml
@@ -35,7 +35,7 @@ create temporary table dynamicplaylist_random_albums as
 								genre_track.genre=genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinArtistTracks'
+			having totaltrackcount >= 'PlaylistMinArtistTracks'
 		order by avgcount asc, random()
 		limit 30) as leastavgplayed
 	order by random()

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_artists/zz_CONTEXTMENU_for_selected_artist_b07_albums_neverplayed.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_artists/zz_CONTEXTMENU_for_selected_artist_b07_albums_neverplayed.sql.xml
@@ -32,7 +32,7 @@ create temporary table dynamicplaylist_random_albums as
 							genre_track.genre=genres.id and
 							genres.name in ('PlaylistExcludedGenres'))
 	group by tracks.album
-		having totaltrackcount > 'PlaylistMinArtistTracks' and sumplaycount = 0
+		having totaltrackcount >= 'PlaylistMinArtistTracks' and sumplaycount = 0
 	order by random()
 	limit 1;
 select distinct tracks.url from tracks

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_artists/zz_CONTEXTMENU_for_selected_artist_b08_albums_playedlongago.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_artists/zz_CONTEXTMENU_for_selected_artist_b08_albums_playedlongago.sql.xml
@@ -33,7 +33,7 @@ create temporary table dynamicplaylist_random_albums as
 							genre_track.genre=genres.id and
 							genres.name in ('PlaylistExcludedGenres'))
 	group by tracks.album
-		having totaltrackcount > 'PlaylistMinArtistTracks' and ((strftime('%s',DATE('NOW','-'PlaylistPeriodPlayedLongAgo' YEAR'))-max(ifnull(tracks_persistent.lastPlayed,0))) > 0)
+		having totaltrackcount >= 'PlaylistMinArtistTracks' and ((strftime('%s',DATE('NOW','-'PlaylistPeriodPlayedLongAgo' YEAR'))-max(ifnull(tracks_persistent.lastPlayed,0))) > 0)
 	order by random()
 	limit 1;
 select distinct tracks.url from tracks

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_genres/zz_CONTEXTMENU_for_selected_genre_b01_albums_random.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_genres/zz_CONTEXTMENU_for_selected_genre_b01_albums_random.sql.xml
@@ -27,7 +27,7 @@ create temporary table dynamicplaylist_random_albums as
 					else 1
 				end
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks'
+			having totaltrackcount >= 'PlaylistMinAlbumTracks'
 		order by random()
 		limit 1;
 select distinct tracks.url from tracks

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_genres/zz_CONTEXTMENU_for_selected_genre_b02_albums_topavgrated.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_genres/zz_CONTEXTMENU_for_selected_genre_b02_albums_topavgrated.sql.xml
@@ -28,7 +28,7 @@ create temporary table dynamicplaylist_random_albums as
 					else 1
 				end
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks'
+			having totaltrackcount >= 'PlaylistMinAlbumTracks'
 		order by avgrating desc, random()
 		limit 30) as topavgrated
 	order by random()

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_genres/zz_CONTEXTMENU_for_selected_genre_b03_albums_mostplayed_absolute.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_genres/zz_CONTEXTMENU_for_selected_genre_b03_albums_mostplayed_absolute.sql.xml
@@ -28,7 +28,7 @@ create temporary table dynamicplaylist_random_albums as
 					else 1
 				end
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks'
+			having totaltrackcount >= 'PlaylistMinAlbumTracks'
 		order by sumcount desc, random()
 		limit 30) as mostplayed
 	order by random()

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_genres/zz_CONTEXTMENU_for_selected_genre_b04_albums_mostplayed_avg.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_genres/zz_CONTEXTMENU_for_selected_genre_b04_albums_mostplayed_avg.sql.xml
@@ -28,7 +28,7 @@ create temporary table dynamicplaylist_random_albums as
 					else 1
 				end
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks'
+			having totaltrackcount >= 'PlaylistMinAlbumTracks'
 		order by avgcount desc, random()
 		limit 30) as mostavgplayed
 	order by random()

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_genres/zz_CONTEXTMENU_for_selected_genre_b05_albums_leastplayed_absolute.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_genres/zz_CONTEXTMENU_for_selected_genre_b05_albums_leastplayed_absolute.sql.xml
@@ -28,7 +28,7 @@ create temporary table dynamicplaylist_random_albums as
 					else 1
 				end
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks'
+			having totaltrackcount >= 'PlaylistMinAlbumTracks'
 		order by sumcount asc, random()
 		limit 30) as leastplayed
 	order by random()

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_genres/zz_CONTEXTMENU_for_selected_genre_b06_albums_leastplayed_avg.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_genres/zz_CONTEXTMENU_for_selected_genre_b06_albums_leastplayed_avg.sql.xml
@@ -28,7 +28,7 @@ create temporary table dynamicplaylist_random_albums as
 					else 1
 				end
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks'
+			having totaltrackcount >= 'PlaylistMinAlbumTracks'
 		order by avgcount asc, random()
 		limit 30) as leastavgplayed
 	order by random()

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_genres/zz_CONTEXTMENU_for_selected_genre_b07_albums_neverplayed.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_genres/zz_CONTEXTMENU_for_selected_genre_b07_albums_neverplayed.sql.xml
@@ -26,7 +26,7 @@ create temporary table dynamicplaylist_random_albums as
 					else 1
 				end
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks' and sumplaycount = 0
+			having totaltrackcount >= 'PlaylistMinAlbumTracks' and sumplaycount = 0
 		order by random()
 		limit 1;
 select distinct tracks.url from tracks

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_genres/zz_CONTEXTMENU_for_selected_genre_b08_albums_playedlongago.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_genres/zz_CONTEXTMENU_for_selected_genre_b08_albums_playedlongago.sql.xml
@@ -27,7 +27,7 @@ create temporary table dynamicplaylist_random_albums as
 					else 1
 				end
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks' and ((strftime('%s',DATE('NOW','-'PlaylistPeriodPlayedLongAgo' YEAR'))-max(ifnull(tracks_persistent.lastPlayed,0))) > 0)
+			having totaltrackcount >= 'PlaylistMinAlbumTracks' and ((strftime('%s',DATE('NOW','-'PlaylistPeriodPlayedLongAgo' YEAR'))-max(ifnull(tracks_persistent.lastPlayed,0))) > 0)
 		order by random()
 		limit 1;
 select distinct tracks.url from tracks

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_genres/zz_CONTEXTMENU_for_selected_genre_c01_artists_random.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_genres/zz_CONTEXTMENU_for_selected_genre_c01_artists_random.sql.xml
@@ -32,7 +32,7 @@ create temporary table dynamicplaylist_random_contributors as
 								genre_track.genre=genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by contributor_track.contributor
-			having totaltrackcount > 'PlaylistMinArtistTracks'
+			having totaltrackcount >= 'PlaylistMinArtistTracks'
 		order by random()
 		limit 1;
 select distinct tracks.url from tracks

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_genres/zz_CONTEXTMENU_for_selected_genre_c02_artists_topavgrated.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_genres/zz_CONTEXTMENU_for_selected_genre_c02_artists_topavgrated.sql.xml
@@ -35,7 +35,7 @@ create temporary table dynamicplaylist_random_contributors as
 								genre_track.genre=genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by contributor_track.contributor
-			having totaltrackcount > 'PlaylistMinArtistTracks'
+			having totaltrackcount >= 'PlaylistMinArtistTracks'
 		order by avgrating desc, random()
 		limit 30) as topavgrated
 	order by random()

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_genres/zz_CONTEXTMENU_for_selected_genre_c03_artists_mostplayed_absolute.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_genres/zz_CONTEXTMENU_for_selected_genre_c03_artists_mostplayed_absolute.sql.xml
@@ -35,7 +35,7 @@ create temporary table dynamicplaylist_random_contributors as
 								genre_track.genre=genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by contributor_track.contributor
-			having totaltrackcount > 'PlaylistMinArtistTracks'
+			having totaltrackcount >= 'PlaylistMinArtistTracks'
 		order by sumcount desc, random()
 		limit 30) as mostplayed
 	order by random()

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_genres/zz_CONTEXTMENU_for_selected_genre_c04_artists_mostplayed_avg.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_genres/zz_CONTEXTMENU_for_selected_genre_c04_artists_mostplayed_avg.sql.xml
@@ -35,7 +35,7 @@ create temporary table dynamicplaylist_random_contributors as
 								genre_track.genre=genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by contributor_track.contributor
-			having totaltrackcount > 'PlaylistMinArtistTracks'
+			having totaltrackcount >= 'PlaylistMinArtistTracks'
 		order by avgcount desc, random()
 		limit 30) as mostavgplayed
 	order by random()

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_genres/zz_CONTEXTMENU_for_selected_genre_c05_artists_leastplayed_absolute.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_genres/zz_CONTEXTMENU_for_selected_genre_c05_artists_leastplayed_absolute.sql.xml
@@ -35,7 +35,7 @@ create temporary table dynamicplaylist_random_contributors as
 								genre_track.genre=genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by contributor_track.contributor
-			having totaltrackcount > 'PlaylistMinArtistTracks'
+			having totaltrackcount >= 'PlaylistMinArtistTracks'
 		order by sumcount asc, random()
 		limit 30) as leastplayed
 	order by random()

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_genres/zz_CONTEXTMENU_for_selected_genre_c06_artists_leastplayed_avg.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_genres/zz_CONTEXTMENU_for_selected_genre_c06_artists_leastplayed_avg.sql.xml
@@ -35,7 +35,7 @@ create temporary table dynamicplaylist_random_contributors as
 								genre_track.genre=genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by contributor_track.contributor
-			having totaltrackcount > 'PlaylistMinArtistTracks'
+			having totaltrackcount >= 'PlaylistMinArtistTracks'
 		order by avgcount asc, random()
 		limit 30) as leastavgplayed
 	order by random()

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_genres/zz_CONTEXTMENU_for_selected_genre_c07_artists_neverplayed.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_genres/zz_CONTEXTMENU_for_selected_genre_c07_artists_neverplayed.sql.xml
@@ -35,7 +35,7 @@ create temporary table dynamicplaylist_random_contributors as
 								genre_track.genre=genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by contributor_track.contributor
-			having totaltrackcount > 'PlaylistMinArtistTracks' and sumplaycount = 0
+			having totaltrackcount >= 'PlaylistMinArtistTracks' and sumplaycount = 0
 		order by random()
 		limit 1;
 select distinct tracks.url from tracks

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_genres/zz_CONTEXTMENU_for_selected_genre_c08_artists_playedlongago.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_genres/zz_CONTEXTMENU_for_selected_genre_c08_artists_playedlongago.sql.xml
@@ -34,7 +34,7 @@ create temporary table dynamicplaylist_random_contributors as
 								genre_track.genre=genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by contributor_track.contributor
-			having totaltrackcount > 'PlaylistMinArtistTracks' and ((strftime('%s',DATE('NOW','-'PlaylistPeriodPlayedLongAgo' YEAR'))-max(ifnull(tracks_persistent.lastPlayed,0))) > 0)
+			having totaltrackcount >= 'PlaylistMinArtistTracks' and ((strftime('%s',DATE('NOW','-'PlaylistPeriodPlayedLongAgo' YEAR'))-max(ifnull(tracks_persistent.lastPlayed,0))) > 0)
 		order by random()
 		limit 1;
 select distinct tracks.url from tracks

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_playlists/zz_CONTEXTMENU_for_selected_playlist_b01_albums_random.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_playlists/zz_CONTEXTMENU_for_selected_playlist_b01_albums_random.sql.xml
@@ -31,7 +31,7 @@ create temporary table dynamicplaylist_random_albums as
 								genre_track.genre=genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks'
+			having totaltrackcount >= 'PlaylistMinAlbumTracks'
 		order by random()
 		limit 1;
 select distinct playlist_track.track from playlist_track

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_years/zz_CONTEXTMENU_for_selected_year_b01_albums_random.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_years/zz_CONTEXTMENU_for_selected_year_b01_albums_random.sql.xml
@@ -37,7 +37,7 @@ create temporary table dynamicplaylist_random_albums as
 								genre_track.genre=genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks'
+			having totaltrackcount >= 'PlaylistMinAlbumTracks'
 		order by random()
 		limit 1;
 select distinct tracks.url from tracks

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_years/zz_CONTEXTMENU_for_selected_year_b02_albums_randomfromthisdecade.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_years/zz_CONTEXTMENU_for_selected_year_b02_albums_randomfromthisdecade.sql.xml
@@ -37,7 +37,7 @@ create temporary table dynamicplaylist_random_albums as
 								genre_track.genre=genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks'
+			having totaltrackcount >= 'PlaylistMinAlbumTracks'
 		order by random()
 		limit 1;
 select distinct tracks.url from tracks

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_years/zz_CONTEXTMENU_for_selected_year_b03_albums_topavgrated.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_years/zz_CONTEXTMENU_for_selected_year_b03_albums_topavgrated.sql.xml
@@ -33,7 +33,7 @@ create temporary table dynamicplaylist_random_albums as
 								genre_track.genre=genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks'
+			having totaltrackcount >= 'PlaylistMinAlbumTracks'
 		order by avgrating desc, random()
 		limit 30) as topavgrated
 	order by random()

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_years/zz_CONTEXTMENU_for_selected_year_b04_albums_topavgratedfromthisdecade.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_years/zz_CONTEXTMENU_for_selected_year_b04_albums_topavgratedfromthisdecade.sql.xml
@@ -33,7 +33,7 @@ create temporary table dynamicplaylist_random_albums as
 								genre_track.genre=genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks'
+			having totaltrackcount >= 'PlaylistMinAlbumTracks'
 		order by avgrating desc, random()
 		limit 30) as topavgrated
 	order by random()

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_years/zz_CONTEXTMENU_for_selected_year_b05_albums_mostplayed_absolute.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_years/zz_CONTEXTMENU_for_selected_year_b05_albums_mostplayed_absolute.sql.xml
@@ -33,7 +33,7 @@ create temporary table dynamicplaylist_random_albums as
 								genre_track.genre=genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks'
+			having totaltrackcount >= 'PlaylistMinAlbumTracks'
 		order by sumcount desc, random()
 		limit 30) as mostplayed
 	order by random()

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_years/zz_CONTEXTMENU_for_selected_year_b06_albums_mostplayedfromthisdecade_absolute.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_years/zz_CONTEXTMENU_for_selected_year_b06_albums_mostplayedfromthisdecade_absolute.sql.xml
@@ -33,7 +33,7 @@ create temporary table dynamicplaylist_random_albums as
 								genre_track.genre=genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks'
+			having totaltrackcount >= 'PlaylistMinAlbumTracks'
 		order by sumcount desc, random()
 		limit 30) as mostplayed
 	order by random()

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_years/zz_CONTEXTMENU_for_selected_year_b07_albums_mostplayed_avg.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_years/zz_CONTEXTMENU_for_selected_year_b07_albums_mostplayed_avg.sql.xml
@@ -33,7 +33,7 @@ create temporary table dynamicplaylist_random_albums as
 								genre_track.genre=genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks'
+			having totaltrackcount >= 'PlaylistMinAlbumTracks'
 		order by avgcount desc, random()
 		limit 30) as mostavgplayed
 	order by random()

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_years/zz_CONTEXTMENU_for_selected_year_b08_albums_mostplayedfromthisdecade_avg.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_years/zz_CONTEXTMENU_for_selected_year_b08_albums_mostplayedfromthisdecade_avg.sql.xml
@@ -33,7 +33,7 @@ create temporary table dynamicplaylist_random_albums as
 								genre_track.genre=genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks'
+			having totaltrackcount >= 'PlaylistMinAlbumTracks'
 		order by avgcount desc, random()
 		limit 30) as mostavgplayed
 	order by random()

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_years/zz_CONTEXTMENU_for_selected_year_b09_albums_leastplayed_absolute.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_years/zz_CONTEXTMENU_for_selected_year_b09_albums_leastplayed_absolute.sql.xml
@@ -33,7 +33,7 @@ create temporary table dynamicplaylist_random_albums as
 								genre_track.genre=genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks'
+			having totaltrackcount >= 'PlaylistMinAlbumTracks'
 		order by sumcount asc, random()
 		limit 30) as leastplayed
 	order by random()

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_years/zz_CONTEXTMENU_for_selected_year_b10_albums_leastplayedfromthisdecade_absolute.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_years/zz_CONTEXTMENU_for_selected_year_b10_albums_leastplayedfromthisdecade_absolute.sql.xml
@@ -33,7 +33,7 @@ create temporary table dynamicplaylist_random_albums as
 								genre_track.genre=genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks'
+			having totaltrackcount >= 'PlaylistMinAlbumTracks'
 		order by sumcount asc, random()
 		limit 30) as leastplayed
 	order by random()

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_years/zz_CONTEXTMENU_for_selected_year_b11_albums_leastplayed_avg.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_years/zz_CONTEXTMENU_for_selected_year_b11_albums_leastplayed_avg.sql.xml
@@ -33,7 +33,7 @@ create temporary table dynamicplaylist_random_albums as
 								genre_track.genre=genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks'
+			having totaltrackcount >= 'PlaylistMinAlbumTracks'
 		order by avgcount asc, random()
 		limit 30) as leastavgplayed
 	order by random()

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_years/zz_CONTEXTMENU_for_selected_year_b12_albums_leastplayedfromthisdecade_avg.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_years/zz_CONTEXTMENU_for_selected_year_b12_albums_leastplayedfromthisdecade_avg.sql.xml
@@ -33,7 +33,7 @@ create temporary table dynamicplaylist_random_albums as
 								genre_track.genre=genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks'
+			having totaltrackcount >= 'PlaylistMinAlbumTracks'
 		order by avgcount asc, random()
 		limit 30) as leastavgplayed
 	order by random()

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_years/zz_CONTEXTMENU_for_selected_year_b13_albums_neverplayed.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_years/zz_CONTEXTMENU_for_selected_year_b13_albums_neverplayed.sql.xml
@@ -31,7 +31,7 @@ create temporary table dynamicplaylist_random_albums as
 								genre_track.genre=genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks' and sumplaycount = 0
+			having totaltrackcount >= 'PlaylistMinAlbumTracks' and sumplaycount = 0
 		order by random()
 		limit 1;
 select distinct tracks.url from tracks

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_years/zz_CONTEXTMENU_for_selected_year_b14_albums_neverplayedfromthisdecade.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_years/zz_CONTEXTMENU_for_selected_year_b14_albums_neverplayedfromthisdecade.sql.xml
@@ -31,7 +31,7 @@ create temporary table dynamicplaylist_random_albums as
 								genre_track.genre=genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks' and sumplaycount = 0
+			having totaltrackcount >= 'PlaylistMinAlbumTracks' and sumplaycount = 0
 		order by random()
 		limit 1;
 select distinct tracks.url from tracks

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_years/zz_CONTEXTMENU_for_selected_year_b15_albums_playedlongago.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_years/zz_CONTEXTMENU_for_selected_year_b15_albums_playedlongago.sql.xml
@@ -32,7 +32,7 @@ create temporary table dynamicplaylist_random_albums as
 								genre_track.genre=genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks' and ((strftime('%s',DATE('NOW','-'PlaylistPeriodPlayedLongAgo' YEAR'))-max(ifnull(tracks_persistent.lastPlayed,0))) > 0)
+			having totaltrackcount >= 'PlaylistMinAlbumTracks' and ((strftime('%s',DATE('NOW','-'PlaylistPeriodPlayedLongAgo' YEAR'))-max(ifnull(tracks_persistent.lastPlayed,0))) > 0)
 		order by random()
 		limit 1;
 select distinct tracks.url from tracks

--- a/DynamicPlaylists3/Playlists/zz_contextmenulists/for_years/zz_CONTEXTMENU_for_selected_year_b16_albums_playedlongagofromthisdecade.sql.xml
+++ b/DynamicPlaylists3/Playlists/zz_contextmenulists/for_years/zz_CONTEXTMENU_for_selected_year_b16_albums_playedlongagofromthisdecade.sql.xml
@@ -32,7 +32,7 @@ create temporary table dynamicplaylist_random_albums as
 								genre_track.genre=genres.id and
 								genres.name in ('PlaylistExcludedGenres'))
 		group by tracks.album
-			having totaltrackcount > 'PlaylistMinAlbumTracks' and ((strftime('%s',DATE('NOW','-'PlaylistPeriodPlayedLongAgo' YEAR'))-max(ifnull(tracks_persistent.lastPlayed,0))) > 0)
+			having totaltrackcount >= 'PlaylistMinAlbumTracks' and ((strftime('%s',DATE('NOW','-'PlaylistPeriodPlayedLongAgo' YEAR'))-max(ifnull(tracks_persistent.lastPlayed,0))) > 0)
 		order by random()
 		limit 1;
 select distinct tracks.url from tracks


### PR DESCRIPTION
Hi @AF-1, I again come across the fact that I had 99,8% of album played and yet none on the unplayed album dynamic playlist. While digging a little deeper, I found that the missing ones were albums with only one track.

The issue comes from the fact that you limited `PlaylistMinAlbumTracks` and `PlaylistMinAlbumTracks` values to min 1 and use a strictly above on the SQL requests.
I changed on the SQL part instead of allowing a min value at 0 as I think it is easier to understand.