### PR TITLE
Fix excluding the right playlist songs for DPL 81

### DIFF
--- a/DynamicPlaylists4/Playlists/songs/songs_081_random_not_in_playlist.sql
+++ b/DynamicPlaylists4/Playlists/songs/songs_081_random_not_in_playlist.sql
@@ -31,7 +31,7 @@ select tracks.id, tracks.primary_artist from tracks
 						where
 							t3.url = tracks.url and
 							tracks.url = playlist_track.track and
-							playlist_track.playlist != 'PlaylistParameter1')
+							playlist_track.playlist = 'PlaylistParameter1')
 		and not exists (select * from tracks t2,genre_track,genres
 						where
 							t2.id = tracks.id and


### PR DESCRIPTION
This fix makes sure that the songs from the playlist selected in the interface will be ignored instead of all other songs that happen to be in another playlist.

The query stays pretty fast performing locally, although it seems to make quite some more time to generate the first playlist though.