### PR TITLE
Use latest Material helper method to name the Home Extras

### DIFF
--- a/DynamicPlaylists4/HomeExtras.pm
+++ b/DynamicPlaylists4/HomeExtras.pm
@@ -39,19 +39,27 @@ use utf8;
 use base qw(Plugins::MaterialSkin::HomeExtraBase);
 
 use Slim::Utils::Prefs;
-use Slim::Utils::Log;
 use Plugins::DynamicPlaylists4::Plugin;
 
 sub initPlugin {
 	my ($class, %args) = @_;
 
 	my $tag = $args{tag};
+	my $prefs = preferences('plugin.dynamicplaylists4');
+	my $title = $args{title};
+
+	if (my $playlistId = $prefs->get("homeextras_$tag")) {
+		my $playlist = Plugins::DynamicPlaylists4::Plugin::getPlayList(undef, $playlistId);
+		if ($playlist && (my $name = $playlist->{name})) {
+			$title = $name;
+		}
+	}
 
 	$class->SUPER::initPlugin(
 		feed => sub { handleFeed($tag, @_) },
 		tag => "DynamicPlaylistsExtras${tag}",
 		extra => {
-			title => $args{title},
+			title => $title,
 			subtitle => $args{subtitle},
 			icon => $args{icon} || Plugins::DynamicPlaylists4::Plugin->_pluginDataFor('icon'),
 			needsPlayer => 1,

--- a/DynamicPlaylists4/Settings/HomeExtras.pm
+++ b/DynamicPlaylists4/Settings/HomeExtras.pm
@@ -37,10 +37,26 @@ my $log = logger('plugin.dynamicplaylists4');
 
 my $plugin;
 
+my @homeExtraItemsPrefs = qw(homeextras_dynamicalbumdiscovery01 homeextras_dynamicalbumdiscovery02 homeextras_dynamicartistdiscovery01);
 
 sub new {
 	my $class = shift;
 	$plugin = shift;
+
+	if (Plugins::MaterialSkin::Plugin->can('setHomeExtraTitle')) {
+		$prefs->setChange(sub {
+			my ($pref, $value, $client) = @_;
+
+			my $playlist = Plugins::DynamicPlaylists4::Plugin::getPlayList($client, $value) if $value;
+
+			if ($playlist && (my $name = $playlist->{name})) {
+				my $homeExtraId = $pref;
+				$homeExtraId =~ s/^homeextras_/DynamicPlaylistsExtras/;
+				Plugins::MaterialSkin::Plugin->setHomeExtraTitle($homeExtraId, $name);
+			}
+		}, @homeExtraItemsPrefs);
+	}
+
 	$class->SUPER::new($plugin);
 }
 sub name {
@@ -65,7 +81,7 @@ sub pages {
 }
 
 sub prefs {
-	return ($prefs, qw(homeextras_dynamicalbumdiscovery01 homeextras_dynamicalbumdiscovery02 homeextras_dynamicartistdiscovery01));
+	return ($prefs, @homeExtraItemsPrefs);
 }
 
 sub handler {
@@ -75,7 +91,5 @@ sub handler {
 
 	return $class->SUPER::handler($client, $paramRef);
 }
-
-*escape = \&URI::Escape::uri_escape_utf8;
 
 1;


### PR DESCRIPTION
Please note that the relevant change in Material must be merged first.

I'm not sure about the implications of fetching the playlists on all these changes. I'm being naive here, assuming things will be all right. If it's working on my MacBook Pro, it should be good enough to run on a 10y old Raspberry Pi, too, right? 🤣 Let me know if this is too heavy. The heavy lifting should only happen when you modify one of the Home Extras sections.

https://github.com/CDrummond/lms-material/pull/1173